### PR TITLE
Allow container to run in unprivileged mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,14 +60,8 @@ VOLUME /config /downloads
 COPY openvpn/ /etc/openvpn/
 COPY qbittorrent/ /etc/qbittorrent/
 
-RUN \
-    # Make scripts executable
-    chmod +x /etc/qbittorrent/*.sh /etc/openvpn/*.sh; \
-
-    # Modify wg-quick to run in unprivileged container
-    apk add --no-cache sed; \
-    sed -i -E 's/&& cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1//gm' $(command -v wg-quick); \
-    apk del --no-cache --purge sed
+# Make scripts executable
+RUN chmod +x /etc/qbittorrent/*.sh /etc/openvpn/*.sh
 
 # qBittorrent ports
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -26,29 +26,35 @@ I recommend building it yourself if you want to always get the most up to date i
 $ git clone https://github.com/trigus42/qbittorrentvpn
 $ cd qbittorrentvpn
 $ docker build -t qbittorrentvpn .
-$ docker run --privileged  -d \
-              -v /your/config/path/:/config \
-              -v /your/downloads/path/:/downloads \
-              -e "VPN_ENABLED=yes" \
-              -e "VPN_TYPE=wireguard" \
-              -e "LAN_NETWORK=192.168.0.0/24" \
-              -p 8080:8080 \
-              --restart unless-stopped \
-              qbittorrentvpn
+$ docker run -d \
+             -v /your/config/path/:/config \
+             -v /your/downloads/path/:/downloads \
+             -e "VPN_ENABLED=yes" \
+             -e "VPN_TYPE=wireguard" \
+             -e "LAN_NETWORK=192.168.0.0/24" \
+             -p 8080:8080 \
+             --restart unless-stopped \
+             --cap-add=NET_ADMIN \
+             --cap-add=SYS_MODULE \
+             --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+             qbittorrentvpn
 ```
 
 The container is also available from the Docker registry:
 
 ```
-$ docker run --privileged  -d \
-              -v /your/config/path/:/config \
-              -v /your/downloads/path/:/downloads \
-              -e "VPN_ENABLED=yes" \
-              -e "VPN_TYPE=wireguard" \
-              -e "LAN_NETWORK=192.168.0.0/24" \
-              -p 8080:8080 \
-              --restart unless-stopped \
-              trigus42/qbittorrentvpn
+$ docker run -d \
+             -v /your/config/path/:/config \
+             -v /your/downloads/path/:/downloads \
+             -e "VPN_ENABLED=yes" \
+             -e "VPN_TYPE=wireguard" \
+             -e "LAN_NETWORK=192.168.0.0/24" \
+             -p 8080:8080 \
+             --restart unless-stopped \
+             --cap-add=NET_ADMIN \
+             --cap-add=SYS_MODULE \
+             --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+             trigus42/qbittorrentvpn
 ```
 
 ## Docker Tags

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Docker container which runs the latest [qBittorrent](https://github.com/qbittorrent/qBittorrent)-nox client while connecting to WireGuard or OpenVPN with iptables killswitch to prevent IP leakage when the tunnel goes down.
 
-# Features
+## Features
 
 * Build for **amd64**, **arm64**, **armv8** and **armv7**
 * Selectively enable or disable WireGuard or OpenVPN support
@@ -13,13 +13,13 @@ Docker container which runs the latest [qBittorrent](https://github.com/qbittorr
 * Configurable UID and GID for config files and /downloads for qBittorrent
 * BitTorrent port 8999 exposed by default
 
-# Software
+## Software
 * Base: alpine
 * [qBittorrent](https://github.com/qbittorrent/qBittorrent) compiled from source
 * [libtorrent](https://github.com/arvidn/libtorrent) compiled from source
 * WireGuard / OpenVPN
 
-# Run container
+## Run container
 I recommend building it yourself if you want to always get the most up to date image:
 
 ```
@@ -64,8 +64,8 @@ $ docker run -d \
 | `trigus42/qbittorrentvpn:alpine-YYYYMMDD` | Alpine based image build on YYYYMMDD |
 | `trigus42/qbittorrentvpn:testing` | Unstable, untested image |
 
-# Variables, Volumes, and Ports
-## Environment Variables
+## Variables, Volumes, and Ports
+### Environment Variables
 | Variable | Required | Function | Example | Default |
 |----------|----------|----------|----------|----------|
 |`VPN_ENABLED`| Yes | Enable VPN (yes/no)?|`VPN_ENABLED=yes`|`yes`|
@@ -84,41 +84,41 @@ $ docker run -d \
 |`INSTALL_PYTHON3`| No |Set this to `yes` to let the container install Python3.|`INSTALL_PYTHON3=yes`|`no`|
 |`ADDITIONAL_PORTS`| No |Adding a comma delimited list of ports will allow these ports via the iptables script.|`ADDITIONAL_PORTS=1234,8112`||
 
-## Volumes
+### Volumes
 | Volume | Required | Function | Example |
 |----------|----------|----------|----------|
 | `config` | Yes | qBittorrent, WireGuard and OpenVPN config files | `/your/config/path/:/config`|
 | `downloads` | No | Default downloads path for saving downloads | `/your/downloads/path/:/downloads`|
 
-## Ports
+### Ports
 | Port | Proto | Required | Function | Example |
 |----------|----------|----------|----------|----------|
 | `8080` | TCP | Yes | qBittorrent WebUI | `8080:8080`|
 | `8999` | TCP | Yes | qBittorrent TCP Listening Port | `8999:8999`|
 | `8999` | UDP | Yes | qBittorrent UDP Listening Port | `8999:8999/udp`|
 
-# Access the WebUI
+## Access the WebUI
 Access https://IPADDRESS:PORT from a browser on the same network. (for example: https://192.168.0.90:8080)
 
-## Default Credentials
+### Default Credentials
 
 | Credential | Default Value |
 |----------|----------|
 |`username`| `admin` |
 |`password`| `adminadmin` |
 
-# How to use WireGuard 
+## How to use WireGuard 
 The container will fail to boot if `VPN_ENABLED` is set and there is no valid .conf file present in the /config/wireguard directory. Drop a .conf file from your VPN provider into /config/wireguard and start the container again. The file must have the name `wg0.conf`, or it will fail to start.
 
-# How to use OpenVPN
+## How to use OpenVPN
 The container will fail to boot if `VPN_ENABLED` is set and there is no valid .ovpn file present in the /config/openvpn directory. Drop a .ovpn file from your VPN provider into /config/openvpn (if necessary with additional files like certificates) and start the container again. You may need to edit the ovpn configuration file to load your VPN credentials from a file by setting `auth-user-pass`.
 
 **Note:** The script will use the first ovpn file it finds in the /config/openvpn directory. Adding multiple ovpn files will not start multiple VPN connections.
 
-## Example auth-user-pass option for .ovpn files
+### Example auth-user-pass option for .ovpn files
 `auth-user-pass credentials.conf`
 
-## Example credentials.conf
+### Example credentials.conf
 ```
 username
 password
@@ -131,12 +131,10 @@ User ID (PUID) and Group ID (PGID) can be found by issuing the following command
 id <username>
 ```
 
-# Issues
+## Issues
 If you are having issues with this container please submit an issue on GitHub.  
 Please provide logs, Docker version and other information that can simplify reproducing the issue.  
 If possible, always use the most up to date version of Docker, you operating system, kernel and the container itself. Support is always a best-effort basis.
 
-### Credits:
-[MarkusMcNugen/docker-qBittorrentvpn](https://github.com/MarkusMcNugen/docker-qBittorrentvpn)  
-[DyonR/jackettvpn](https://github.com/DyonR/jackettvpn)  
-[DyonR/docker-qbittorrentvpn](https://github.com/DyonR/docker-qbittorrentvpn)
+## Credits:
+This image is based on [DyonR/docker-qbittorrentvpn](https://github.com/DyonR/docker-qbittorrentvpn) which in turn is based off [MarkusMcNugen/docker-qBittorrentvpn](https://github.com/MarkusMcNugen/docker-qBittorrentvpn) and [binhex/arch-qbittorrentvpn](https://github.com/binhex/arch-qbittorrentvpn).

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Docker container which runs the latest [qBittorrent](https://github.com/qbittorr
 * WireGuard / OpenVPN
 
 ## Run container
-I recommend building it yourself if you want to always get the most up to date image:
-
+&NewLine;
+### Build it yourself
+&NewLine;
 ```
 $ git clone https://github.com/trigus42/qbittorrentvpn
 $ cd qbittorrentvpn
@@ -34,14 +35,11 @@ $ docker run -d \
              -e "LAN_NETWORK=192.168.0.0/24" \
              -p 8080:8080 \
              --restart unless-stopped \
-             --cap-add=NET_ADMIN \
-             --cap-add=SYS_MODULE \
-             --sysctl net.ipv4.conf.all.src_valid_mark=1 \
              qbittorrentvpn
 ```
 
-The container is also available from the Docker registry:
-
+### From the Docker registry
+&NewLine;
 ```
 $ docker run -d \
              -v /your/config/path/:/config \
@@ -51,10 +49,24 @@ $ docker run -d \
              -e "LAN_NETWORK=192.168.0.0/24" \
              -p 8080:8080 \
              --restart unless-stopped \
-             --cap-add=NET_ADMIN \
-             --cap-add=SYS_MODULE \
-             --sysctl net.ipv4.conf.all.src_valid_mark=1 \
              trigus42/qbittorrentvpn
+```
+
+### Run in unprivileged mode
+&NewLine;
+#### Wireguard:
+&NewLine;
+```sh
+-e "UNPRIVILEGED=yes" \
+--cap-add=NET_ADMIN \
+--cap-add=SYS_MODULE \
+--sysctl net.ipv4.conf.all.src_valid_mark=1 \
+```
+
+#### OpenVPN:
+&NewLine;
+```sh
+--cap-add=NET_ADMIN \
 ```
 
 ## Docker Tags
@@ -68,6 +80,7 @@ $ docker run -d \
 ### Environment Variables
 | Variable | Required | Function | Example | Default |
 |----------|----------|----------|----------|----------|
+|`UNPRIVILEGED`| No | Allows container to run in unprivileged mode when wireguard is used |`UNPRIVILEGED=yes`|`no`|
 |`VPN_ENABLED`| Yes | Enable VPN (yes/no)?|`VPN_ENABLED=yes`|`yes`|
 |`VPN_TYPE`| Yes | WireGuard or OpenVPN (wireguard/openvpn)?|`VPN_TYPE=wireguard`|`openvpn`|
 |`VPN_USERNAME`| No | If username and password provided, configures ovpn file automatically |`VPN_USERNAME=ad8f64c02a2de`||

--- a/example-docker-compose.yml
+++ b/example-docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - HEALTH_CHECK_HOST=one.one.one.one
       - HEALTH_CHECK_INTERVAL=300
       - ENABLE_SSL=yes
+      - UNPRIVILEGED=yes
     volumes:
       - '/server/qbittorrent/:/config'
     ports:

--- a/example-docker-compose.yml
+++ b/example-docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.3"
+
+services:
+  qbittorrent:
+    build: ./
+    container_name: qbittorrent
+    environment:
+      - PUID=1001
+      - PGID=1001
+      - UMASK=002
+      - VPN_ENABLED=yes
+      - VPN_TYPE=wireguard
+      - LAN_NETWORK=192.168.0.0/24
+      - HEALTH_CHECK_HOST=one.one.one.one
+      - HEALTH_CHECK_INTERVAL=300
+      - ENABLE_SSL=yes
+    volumes:
+      - '/server/qbittorrent/:/config'
+    ports:
+     # - 80:8080
+      - 443:8080
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Forked from binhex's OpenVPN dockers
 set -e
 
 # check for presence of network interface docker0
@@ -20,19 +19,6 @@ else
 	echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] VPN_ENABLED not defined,(via -e VPN_ENABLED), defaulting to 'yes'"
 	export VPN_ENABLED="yes"
 fi
-
-# export LEGACY_IPTABLES=$(echo "${LEGACY_IPTABLES,,}")
-# echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] LEGACY_IPTABLES is set to '${LEGACY_IPTABLES}'"
-# if [[ $LEGACY_IPTABLES == "1" || $LEGACY_IPTABLES == "true" || $LEGACY_IPTABLES == "yes" ]]; then
-#	echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] Linking /usr/sbin/iptables-legacy to /usr/sbin/iptables"
-#	ln -sf /usr/sbin/iptables-legacy /usr/sbin/iptables > /dev/null 2>&1
-#	echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] Linking /usr/sbin/iptables-legacy-save to /usr/sbin/iptables-save"
-#	ln -sf /usr/sbin/iptables-legacy-save /usr/sbin/iptables-save > /dev/null 2>&1
-#	echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] Linking /usr/sbin/iptables-legacy-restore to /usr/sbin/iptables-restore"
-#	ln -sf /usr/sbin/iptables-legacy-restore /usr/sbin/iptables-restore > /dev/null 2>&1
-# else
-#	echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] Not making any changes to iptables"
-# fi
 
 if [[ $VPN_ENABLED == "yes" ]]; then
 	# Check if VPN_TYPE is set.

--- a/openvpn/start.sh
+++ b/openvpn/start.sh
@@ -12,6 +12,14 @@ if [[ ! -z "${check_network}" ]]; then
 	exit 1
 fi
 
+if [ "${UNPRIVILEGED}" == "yes" ]; then
+	echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] Unprivileged mode enabled"
+	/bin/bash /etc/qbittorrent/unprivileged.sh
+elif [ "${UNPRIVILEGED}" != "no" ]; then
+	echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] Unprivileged not set or invalid value, defaulting to privileged mode."
+	export UNPRIVILEGED=false
+fi
+
 export VPN_ENABLED=$(echo "${VPN_ENABLED,,}" | sed -e 's~^[ \t]*~~;s~[ \t]*$~~')
 if [[ ! -z "${VPN_ENABLED}" ]]; then
 	echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] VPN_ENABLED defined as '${VPN_ENABLED}'"
@@ -253,7 +261,7 @@ if [[ $VPN_ENABLED == "yes" ]]; then
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] Starting WireGuard..."
 		cd /config/wireguard
-		if ip link | grep -q $(basename -s .conf $VPN_CONFIG); then
+		if iplink | grep $(basename "$VPN_CONFIG" .conf); then
 			wg-quick down $VPN_CONFIG || echo "WireGuard is down already" # Run wg-quick down as an extra safeguard in case WireGuard is still up for some reason
 			sleep 0.5 # Just to give WireGuard a bit to go down
 		fi

--- a/qbittorrent/unprivileged.sh
+++ b/qbittorrent/unprivileged.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Check if net.ipv4.conf.all.src_valid_mark is set to 1
+if [ "$(sysctl net.ipv4.conf.all.src_valid_mark)" == "net.ipv4.conf.all.src_valid_mark = 1" ]; then
+    # Update sed
+    apk add --no-cache --quiet sed
+    # Modify wg-quick to run in unprivileged container
+    sed -i -E 's/&& cmd sysctl -q net.ipv4.conf.all.src_valid_mark=1//gm' "$(command -v wg-quick)"
+else
+    echo "$(date +'%Y-%m-%d %H:%M:%S') [ERROR] Trying to run in unprivileged mode but $(sysctl net.ipv4.conf.all.src_valid_mark)"
+    sleep 10
+	exit 1
+fi


### PR DESCRIPTION
When using Wireguard before you had to run the container in privileged mode. Now with the environment variable `UNPRIVILEGED=yes` set you can run the container in unprivileged mode if the necessary caps and sysctl parameters are set (view updated README).

Additional changes:
- Updated README
- Remove credits from individual files; Clarify in README
- `apk -U upgrade` during build replaced with `apk update`