### PR TITLE
Ensure qbittorrent.conf additions are in the right section

### DIFF
--- a/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
+++ b/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
@@ -51,8 +51,7 @@ if [[ ${ENABLE_SSL,,} == 'yes' ]]; then
 	if grep -xq 'WebUI\\HTTPS\\Enabled=true\|WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
 		if grep -xq 'WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
 			echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled set to false, changing it to true."
-                sed -i 's/WebUI\HTTPS\Enabled=false/WebUI\\HTTPS\\Enabled=true/g' "/config/qBittorrent/config/qBittorrent.conf"
-		else
+			sed -i 's/WebUI\\HTTPS\\Enabled=false/WebUI\\HTTPS\\Enabled=true/g' "/config/qBittorrent/config/qBittorrent.conf"		else
 			echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled already set to true."
 		fi
 	else

--- a/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
+++ b/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
@@ -40,24 +40,24 @@ if [[ ${ENABLE_SSL,,} == 'yes' ]]; then
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUICertificate.crt loaded, nothing to do."
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUICertificate.crt loaded. Added it to the config."
-		echo 'WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt' >> "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i '/[Preferences]/a WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt' "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 	if grep -Fxq 'WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' "/config/qBittorrent/config/qBittorrent.conf"; then
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUIKey.key loaded, nothing to do."
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUIKey.key loaded. Added it to the config."
-		echo 'WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' >> "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i '/[Preferences]/a WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 	if grep -xq 'WebUI\\HTTPS\\Enabled=true\|WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
 		if grep -xq 'WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
 			echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled set to false, changing it to true."
-			sed -i 's/WebUI\\HTTPS\\Enabled=false/WebUI\\HTTPS\\Enabled=true/g' "/config/qBittorrent/config/qBittorrent.conf"
+                sed -i 's/WebUI\HTTPS\Enabled=false/WebUI\\HTTPS\\Enabled=true/g' "/config/qBittorrent/config/qBittorrent.conf"
 		else
 			echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled already set to true."
 		fi
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUI\HTTPS\Enabled loaded. Added it to the config."
-		echo 'WebUI\HTTPS\Enabled=true' >> "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i '/[Preferences]/a WebUI\HTTPS\Enabled=true' "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 else
 	echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] ENABLE_SSL is set to ${ENABLE_SSL}, SSL is not enabled. This could cause issues with logging if other apps use the same Cookie name (SID)."

--- a/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
+++ b/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
@@ -40,13 +40,13 @@ if [[ ${ENABLE_SSL,,} == 'yes' ]]; then
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUICertificate.crt loaded, nothing to do."
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUICertificate.crt loaded. Added it to the config."
-		sed -i "/\[Preferences\]/a WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt" "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i "/\[Preferences\]/a WebUI\\\HTTPS\\\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt" "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 	if grep -Fxq 'WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' "/config/qBittorrent/config/qBittorrent.conf"; then
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUIKey.key loaded, nothing to do."
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUIKey.key loaded. Added it to the config."
-		sed -i "/\[Preferences\]/a WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key" "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i "/\[Preferences\]/a WebUI\\\HTTPS\\\KeyPath=/config/qBittorrent/config/WebUIKey.key" "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 	if grep -xq 'WebUI\\HTTPS\\Enabled=true\|WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
 		if grep -xq 'WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
@@ -57,7 +57,7 @@ if [[ ${ENABLE_SSL,,} == 'yes' ]]; then
 		fi
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUI\HTTPS\Enabled loaded. Added it to the config."
-		sed -i "/\[Preferences\]/a WebUI\HTTPS\Enabled=true" "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i "/\[Preferences\]/a WebUI\\\HTTPS\\\Enabled=true" "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 else
 	echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] ENABLE_SSL is set to ${ENABLE_SSL}, SSL is not enabled. This could cause issues with logging if other apps use the same Cookie name (SID)."

--- a/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
+++ b/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
@@ -51,7 +51,8 @@ if [[ ${ENABLE_SSL,,} == 'yes' ]]; then
 	if grep -xq 'WebUI\\HTTPS\\Enabled=true\|WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
 		if grep -xq 'WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
 			echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled set to false, changing it to true."
-			sed -i 's/WebUI\\HTTPS\\Enabled=false/WebUI\\HTTPS\\Enabled=true/g' "/config/qBittorrent/config/qBittorrent.conf"		else
+			sed -i 's/WebUI\\HTTPS\\Enabled=false/WebUI\\HTTPS\\Enabled=true/g' "/config/qBittorrent/config/qBittorrent.conf"
+                else
 			echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf does have the WebUI\HTTPS\Enabled already set to true."
 		fi
 	else

--- a/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
+++ b/rootfs/etc/cont-init.d/04-qbittorrent-setup.sh
@@ -40,13 +40,13 @@ if [[ ${ENABLE_SSL,,} == 'yes' ]]; then
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUICertificate.crt loaded, nothing to do."
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUICertificate.crt loaded. Added it to the config."
-		sed -i '/[Preferences]/a WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt' "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i "/\[Preferences\]/a WebUI\HTTPS\CertificatePath=/config/qBittorrent/config/WebUICertificate.crt" "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 	if grep -Fxq 'WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' "/config/qBittorrent/config/qBittorrent.conf"; then
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [INFO] /config/qBittorrent/config/qBittorrent.conf already has the line WebUIKey.key loaded, nothing to do."
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUIKey.key loaded. Added it to the config."
-		sed -i '/[Preferences]/a WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key' "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i "/\[Preferences\]/a WebUI\HTTPS\KeyPath=/config/qBittorrent/config/WebUIKey.key" "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 	if grep -xq 'WebUI\\HTTPS\\Enabled=true\|WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
 		if grep -xq 'WebUI\\HTTPS\\Enabled=false' "/config/qBittorrent/config/qBittorrent.conf"; then
@@ -57,7 +57,7 @@ if [[ ${ENABLE_SSL,,} == 'yes' ]]; then
 		fi
 	else
 		echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] /config/qBittorrent/config/qBittorrent.conf doesn't have the WebUI\HTTPS\Enabled loaded. Added it to the config."
-		sed -i '/[Preferences]/a WebUI\HTTPS\Enabled=true' "/config/qBittorrent/config/qBittorrent.conf"
+		sed -i "/\[Preferences\]/a WebUI\HTTPS\Enabled=true" "/config/qBittorrent/config/qBittorrent.conf"
 	fi
 else
 	echo "$(date +'%Y-%m-%d %H:%M:%S') [WARNING] ENABLE_SSL is set to ${ENABLE_SSL}, SSL is not enabled. This could cause issues with logging if other apps use the same Cookie name (SID)."


### PR DESCRIPTION
Current methodology with echo can fail if a section other than Preferences is at the bottom of the file. Using sed ensures the commands are put in the Preferences section 