### PR TITLE
Update example-wg-ipv4.yml

### DIFF
--- a/docs/examples/compose/example-wg-ipv4.yml
+++ b/docs/examples/compose/example-wg-ipv4.yml
@@ -16,3 +16,4 @@ services:
       - NET_ADMIN
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv6.conf.all.disable_ipv6=0


### PR DESCRIPTION
When using the provided ipv4 only example file for wg you will get a "RTNETLINK answers: Permission denied" error.
Adding "- net.ipv6.conf.all.disable_ipv6=0" to the docker compose file will solve the issue.

See https://github.com/dperson/openvpn-client/issues/75 for a discussion on the issue.

Also similar to #17