### PR TITLE
Fix incorrect path to `qbittorrent-nox-static-arch` when building with version tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN \
 ARG QBITTORRENT_TAG
 RUN \
     # Install qbittorrent-nox
-    if [ -z $QBITTORRENT_TAG ]; then QBT_DL_PATH="latest/download/$(/bin/sh /tmp/build-scripts/qbittorrent-nox-static-arch)-qbittorrent-nox"; else QBT_DL_PATH="download/$QBITTORRENT_TAG/$(/bin/sh /tmp/build/qbittorrent-nox-static-arch)-qbittorrent-nox"; fi && \
+    if [ -z $QBITTORRENT_TAG ]; then QBT_DL_PATH="latest/download/$(/bin/sh /tmp/build-scripts/qbittorrent-nox-static-arch)-qbittorrent-nox"; else QBT_DL_PATH="download/$QBITTORRENT_TAG/$(/bin/sh /tmp/build-scripts/qbittorrent-nox-static-arch)-qbittorrent-nox"; fi && \
     wget -O /bin/qbittorrent-nox "https://github.com/userdocs/qbittorrent-nox-static/releases/$QBT_DL_PATH" && \
     chmod +x /bin/qbittorrent-nox
 


### PR DESCRIPTION
When I build the docker image with custom `QBITTORRENT_TAG`, the script fails because the path to the `qbittorrent-nox-static-arch` file is incorrect. This commit simply fixes its path.